### PR TITLE
Add GitHub Actions workflow for automatic PR updates from upstream re…

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,16 @@
+name: Upstream to PR
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@master
+    with:
+      upstream_repository: https://github.com/weaviate/weaviate-helm
+      upstream_tag_regex: 'v\d+\..*'
+    secrets:
+      personal_access_token: ${{ secrets.GH_AUTO_PR }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of pull requests for updates from an upstream repository. The most important change is the addition of a new workflow configuration file.

Automation of pull requests:

* [`.github/workflows/auto-pr.yml`](diffhunk://#diff-66bcf23e63818b74faef47f7f8df000b744f92840970c2e649b491adf936c8a1R1-R16): Added a new workflow named "Upstream to PR" that triggers on a schedule and can be manually dispatched. It uses the `neuro-inc/reuse` action to create pull requests for updates from the specified upstream repository.